### PR TITLE
➖ Drop Nipype dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ install:
   - source tests/travis_install.sh
   - pip install -r requirements.txt
   - pip install -r requirements-dev.txt
+  - pip install nipype  # for testing `cpac_read_crash` module that runs in containers
   - pip install twine
   - pip install -e .
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 os: linux
-language: python
+language: go
 dist: bionic
 go:
   - "1.14"

--- a/.travis/setup_singularity.sh
+++ b/.travis/setup_singularity.sh
@@ -13,20 +13,20 @@ echo "sregistry Version:"
 
 # Install Singularity
 
-SINGULARITY_BASE="${GOPATH}/src/github.com/sylabs/singularity"
+SINGULARITY_BASE="${GOPATH}/src/github.com/hpcng/singularity"
 export PATH="${GOPATH}/bin:${PATH}"
 
-mkdir -p "${GOPATH}/src/github.com/sylabs"
-cd "${GOPATH}/src/github.com/sylabs"
+mkdir -p "${GOPATH}/src/github.com/hpcng"
+cd "${GOPATH}/src/github.com/hpcng"
 
-git clone -b 2.6.1 https://github.com/sylabs/singularity
+git clone -b v3.7.1 https://github.com/hpcng/singularity
 cd singularity
 # These are the Singularity 2 installation commands:
-./autogen.sh
-./configure --prefix=/usr/local --sysconfdir=/etc
-make
-sudo make install
+# ./autogen.sh
+# ./configure --prefix=/usr/local --sysconfdir=/etc
+# make
+# sudo make install
 # These are the Singularity 3 installation commands:
-# ./mconfig -v -p /usr/local
-# make -j `nproc 2>/dev/null || echo 1` -C ./builddir all
-# sudo make -C ./builddir install
+./mconfig -v -p /usr/local
+make -j `nproc 2>/dev/null || echo 1` -C ./builddir all
+sudo make -C ./builddir install

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 =========
 Changelog
 =========
+`Version 0.3.2 <https://github.com/FCP-INDI/cpac/releases/tag/v0.3.2>`_
+=======================================================================
+* ➖ Remove dependecy on Nipype
+
 `Version 0.3.1 <https://github.com/FCP-INDI/cpac/releases/tag/v0.3.1>`_
 =======================================================================
 * 🚸 Print without emoji if terminal can't handle extended Unicode set

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 docker >= 4.2.1
 docker-pycreds
-nipype
 pandas >= 0.23.4
 pyyaml
 setuptools

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python :: 3
     Topic :: Scientific/Engineering :: Bio-Informatics
-version = 0.3.1
+version = 0.3.2
 
 [options]
 zip_safe = False
@@ -38,7 +38,6 @@ setup_requires =
 install_requires =
     docker
     docker-pycreds
-    nipype
     pandas >= 0.23.4
     spython >= 0.0.81
     pyyaml

--- a/src/cpac/__main__.py
+++ b/src/cpac/__main__.py
@@ -34,7 +34,8 @@ def parse_args(args):
     parser = argparse.ArgumentParser(
         description='cpac: a Python package that simplifies using C-PAC '
                     '<http://fcp-indi.github.io> containerized images. \n\n'
-                    'This commandline interface package is designed to ' 'minimize repetition.\nAs such, nearly all arguments are '
+                    'This commandline interface package is designed to '
+                    'minimize repetition.\nAs such, nearly all arguments are '
                     'optional.\n\nWhen launching a container, this package '
                     'will try to bind any paths mentioned in \n • the command'
                     '\n • the data configuration\n\nAn example minimal run '

--- a/tests/test_cpac_crash.py
+++ b/tests/test_cpac_crash.py
@@ -19,4 +19,6 @@ def test_cpac_crash(args, capsys):
     with mock.patch.object(sys, 'argv', argv):
         run()
         captured = capsys.readouterr()
-        assert("MemoryError" in captured.out or "MemoryError" in captured.err)
+        assert(
+            "MemoryError" in captured.out or "MemoryError" in captured.err
+        )


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
* Drops local dependency on Nipype
* Raises 
   ```Python
   NoNipype: `cpac_read_crash` is intended to be run inside a C-PAC container.
   The current run environment does not include the package `nipype`.
   ```
   if the module that requires nipype is run outside of a container in an environment without nipype.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
