### PR TITLE
🐛 Pass commandline arguments through to `cpac crash`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 =========
 Changelog
 =========
+`Version 0.3.2 <https://github.com/FCP-INDI/cpac/releases/tag/v0.3.2>`_
+=======================================================================
+* 🐛 Pass commandline arguments through to ``cpac crash``
+
 `Version 0.3.1 <https://github.com/FCP-INDI/cpac/releases/tag/v0.3.1>`_
 =======================================================================
 * 🚸 Print without emoji if terminal can't handle extended Unicode set

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python :: 3
     Topic :: Scientific/Engineering :: Bio-Informatics
-version = 0.3.1
+version = 0.3.2
 
 [options]
 zip_safe = False

--- a/src/cpac/backends/docker.py
+++ b/src/cpac/backends/docker.py
@@ -38,8 +38,10 @@ class Docker(Backend):
                     else:
                         self.docker_kwargs[k] = v
 
-    def _read_crash(self, read_crash_command):
-        return(self._execute(command=read_crash_command, run_type='exec'))
+    def _read_crash(self, read_crash_command, **kwargs):
+        return self._execute(
+            command=read_crash_command, run_type='exec', **kwargs
+        )
 
     def run(self, flags=[], **kwargs):
         kwargs['command'] = [i for i in [

--- a/src/cpac/backends/platform.py
+++ b/src/cpac/backends/platform.py
@@ -29,8 +29,10 @@ class Backend(object):
             self._load_logging()
         stderr = StringIO()
         with redirect_stderr(stderr):
+            del kwargs['command']
             crash_lines = list(self._read_crash(
-                f'{cpac_read_crash.__file__} {crashfile}'
+                f'{cpac_read_crash.__file__} {crashfile}',
+                **kwargs
             ))
             crash_message = ''.join([
                 l.decode('utf-8') if isinstance(l, bytes) else l for l in (

--- a/src/cpac/backends/singularity.py
+++ b/src/cpac/backends/singularity.py
@@ -60,7 +60,7 @@ class Singularity(Backend):
             ] for local in self.volumes])))]
         )
 
-    def _try_to_stream(self, args, stream_command='run'):
+    def _try_to_stream(self, args, stream_command='run', **kwargs):
         self._bindings_as_option()
         try:
             if stream_command == 'run':
@@ -84,9 +84,11 @@ class Singularity(Backend):
         except CalledProcessError:  # pragma: no cover
             return
 
-    def _read_crash(self, read_crash_command):
+    def _read_crash(self, read_crash_command, **kwargs):
         return self._try_to_stream(
-            args={'command': read_crash_command}, stream_command='execute'
+            args={'command': read_crash_command},
+            stream_command='execute',
+            **kwargs
         )
 
     def run(self, flags=[], **kwargs):


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
Passes commandline arguments through to container when running `cpac crash`.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
Passes these arguments in `kwargs`.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [x] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
