### PR TITLE
add memory usage/estimation quick parser utility

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 =========
 Changelog
 =========
+`Unreleased`
+================================================================================================
+* 🧮 Evaluates memory usage for specific nodes from `callback.log` files
+
 `Version 0.4.0: Goodbye Singularity Hub <https://github.com/FCP-INDI/cpac/releases/tag/v0.4.0>`_
 ================================================================================================
 * 👽 Drop call to now-deprecated Singularity Hub

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ spython >= 0.0.81
 tabulate >= 0.8.6
 tornado
 websocket-client
+rich

--- a/src/cpac/helpers/cpac_parse_resources.py
+++ b/src/cpac/helpers/cpac_parse_resources.py
@@ -82,7 +82,7 @@ if __name__ == '__main__':
                         default='efficiency')
     parser.add_argument("--filter_group", "-g", action="store",
                         choices=['lowest', 'highest'], default='lowest')
-    parser.add_argument("--filter_count", "-c", action="store", type=int,
+    parser.add_argument("--filter_count", "-n", action="store", type=int,
                         default=10)
 
     res = parser.parse_args()

--- a/src/cpac/helpers/cpac_parse_resources.py
+++ b/src/cpac/helpers/cpac_parse_resources.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+'''cpac_parse_resources.py
+
+`cpac_parse resources` is intended to be run outside a C-PAC container
+'''
+
+from rich.console import Console
+from rich.table import Table
+
+from argparse import ArgumentParser
+import pandas as pd
+import numpy as np
+import json
+
+
+runti = 'runtime_memory_gb'
+estim = 'estimated_memory_gb'
+
+field = {'runtime': runti,
+         'estimate': estim,
+         'efficiency': 'efficiency'}
+
+
+def display(df):
+    console = Console()
+
+    table = Table(show_header=True, header_style="bold magenta")
+    table.add_column("Task ID", style="dim", width=40)
+    table.add_column("Memory Used")
+    table.add_column("Memory Estimated")
+    table.add_column("Memory Efficiency")
+
+    for _, d in df.iterrows():
+        tmp = list()
+        tmp += [d['id']]
+        tmp += [d[runti]]
+        tmp += [d[estim]]
+        tmp += ["{0:.2f} %".format(100*d[runti] * 1.0 / d[estim])]
+
+        tmp = ["{0:.4f}".format(t) if isinstance(t, float) else str(t)
+               for t in tmp]
+        table.add_row(*tmp)
+        del tmp
+
+    console.print(table)
+
+
+def load_runtime_stats(callback):
+    with open(callback) as fhandle:
+        logs = [json.loads(log) for log in fhandle.readlines()]
+
+    pruned_logs = []
+    for log in logs:
+        if runti not in log.keys():
+            continue
+
+        tmp = {}
+        for k in ['id', runti, estim]:
+            tmp[k] = log[k]
+        tmp['efficiency'] = tmp[runti] / tmp[estim] * 100
+
+        pruned_logs += [tmp]
+        del tmp
+
+    return pd.DataFrame.from_dict(pruned_logs)
+
+
+def query(usage, f, g, c):
+    order = True if g == 'lowest' else False
+    usage.sort_values(by=field[f], ascending=order, inplace=True)
+    usage.reset_index(inplace=True, drop=True)
+    return usage[0:c]
+
+
+if __name__ == '__main__':
+    parser = ArgumentParser(__file__)
+    parser.add_argument("callback",
+                        help="callback.log file found in the 'log' "
+                             "directory of the specified derivatives path")
+    parser.add_argument("--filter_field", "-f", action="store",
+                        choices=['runtime', 'estimate', 'efficiency'],
+                        default='efficiency')
+    parser.add_argument("--filter_group", "-g", action="store",
+                        choices=['lowest', 'highest'], default='lowest')
+    parser.add_argument("--filter_count", "-c", action="store", type=int,
+                        default=10)
+
+    res = parser.parse_args()
+    usage = load_runtime_stats(res.callback)
+
+    filtered_usage = query(usage, res.filter_field, res.filter_group,
+                           res.filter_count)
+    display(filtered_usage)


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
When provided with a `callback.log` file, this utility can sort through the memory `runtime` usage, `estimate`, and associated `efficiency`, to identify the `n` tasks with the `highest` or `lowest` of each of these categories.

## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

When run on [callback.log](https://github.com/FCP-INDI/cpac/files/8112003/callback.log) to get the 10 least efficient,

```
$ python src/cpac/helpers/cpac_parse_resources.py callback.log -f efficiency -g lowest -n 10
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┓
┃ Task ID                                  ┃ Memory Used ┃ Memory Estimated ┃ Memory Efficiency ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━┩
│ cpac_sub-A007_ses-BAS1.montage_mfi_365.… │ 0.2547      │ 10.3500          │ 2.46 %            │
│ cpac_sub-A007_ses-BAS1.montage_mni_anat… │ 0.2772      │ 10.3500          │ 2.68 %            │
│ cpac_sub-A007_ses-BAS1.carpet_seg_353.c… │ 0.2872      │ 10.3500          │ 2.77 %            │
│ cpac_sub-A007_ses-BAS1.carpet_seg_358.g… │ 0.2888      │ 10.3500          │ 2.79 %            │
│ cpac_sub-A007_ses-BAS1.carpet_seg_353.g… │ 0.2975      │ 10.3500          │ 2.87 %            │
│ cpac_sub-A007_ses-BAS1.carpet_seg_353.w… │ 0.2975      │ 10.3500          │ 2.87 %            │
│ cpac_sub-A007_ses-BAS1.carpet_seg_358.w… │ 0.2991      │ 10.3500          │ 2.89 %            │
│ cpac_sub-A007_ses-BAS1.carpet_seg_358.c… │ 0.2992      │ 10.3500          │ 2.89 %            │
│ cpac_sub-A007_ses-BAS1.montage_mni_anat… │ 0.3324      │ 10.3500          │ 3.21 %            │
│ cpac_sub-A007_ses-BAS1.montage_mfi_365.… │ 0.3362      │ 10.3500          │ 3.25 %            │
└──────────────────────────────────────────┴─────────────┴──────────────────┴───────────────────┘
```

or, the 5 most memory intensive:
```
$ python src/cpac/helpers/cpac_parse_resources.py callback.log -f runtime -g highest -n 5
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┓
┃ Task ID                                  ┃ Memory Used ┃ Memory Estimated ┃ Memory Efficiency ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━┩
│ cpac_sub-A007_ses-BAS1.segment_75        │ 1.5509      │ 3.5151           │ 44.12 %           │
│ cpac_sub-A007_ses-BAS1.ANTS_T1_to_templ… │ 1.1426      │ 3.3572           │ 34.04 %           │
│ cpac_sub-A007_ses-BAS1.ANTS_T1_to_templ… │ 1.1017      │ 3.3572           │ 32.82 %           │
│ cpac_sub-A007_ses-BAS1.ANTS_T1_to_templ… │ 1.0256      │ 2.3476           │ 43.69 %           │
│ cpac_sub-A007_ses-BAS1.ANTS_T1_to_templ… │ 1.0226      │ 2.3476           │ 43.56 %           │
└──────────────────────────────────────────┴─────────────┴──────────────────┴───────────────────┘

```

The help-text is as follows:
```
$ python src/cpac/helpers/cpac_parse_resources.py -h
usage: src/cpac/helpers/cpac_parse_resources.py [-h] [--filter_field {runtime,estimate,efficiency}]
                                                [--filter_group {lowest,highest}]
                                                [--filter_count FILTER_COUNT]
                                                callback

positional arguments:
  callback              callback.log file found in the 'log' directory of the specified derivatives
                        path

optional arguments:
  -h, --help            show this help message and exit
  --filter_field {runtime,estimate,efficiency}, -f {runtime,estimate,efficiency}
  --filter_group {lowest,highest}, -g {lowest,highest}
  --filter_count FILTER_COUNT, -n FILTER_COUNT

```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [x] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
